### PR TITLE
Fix: Avoid unhandled revert in WitnetBuffer.memcpy(..)

### DIFF
--- a/contracts/libs/WitnetBuffer.sol
+++ b/contracts/libs/WitnetBuffer.sol
@@ -237,13 +237,14 @@ library WitnetBuffer {
       _dest += 32;
       _src += 32;
     }
-
-    // Copy remaining bytes
-    uint mask = 256 ** (32 - _len) - 1;
-    assembly {
-      let srcpart := and(mload(_src), not(mask))
-      let destpart := and(mload(_dest), mask)
-      mstore(_dest, or(destpart, srcpart))
+    if (_len > 0) {
+      // Copy remaining bytes
+      uint mask = 256 ** (32 - _len) - 1;
+      assembly {
+        let srcpart := and(mload(_src), not(mask))
+        let destpart := and(mload(_dest), mask)
+        mstore(_dest, or(destpart, srcpart))
+      }
     }
   }
 

--- a/migrations/witnet.addresses.js
+++ b/migrations/witnet.addresses.js
@@ -1,15 +1,15 @@
 module.exports = {
   default: {
     "ethereum.goerli": {
-      WitnetParserLib: "0x46cF0c52f7B2e76F1E95fe163B98F92413f1d5A4",
+      WitnetParserLib: "0x7fbFAA0cA6B098e234135a9D813f735762fEF601",
       WitnetRequestBoard: "0xb58D05247d16b3F1BD6B59c52f7f61fFef02BeC8",
     },
     "ethereum.mainnet": {
-      WitnetParserLib: "",
-      WitnetRequestBoard: "",
+      WitnetParserLib: "0xfAB822EcFEdC440D505F731e78786C4a6b39B553",
+      WitnetRequestBoard: "0x9E4fae1c7ac543a81E4E2a5486a0dDaad8194bdA",
     },
     "ethereum.rinkeby": {
-      WitnetParserLib: "0x14b5cAC222d55Cb11CC9fE5Fbf6793177B3048F6",
+      WitnetParserLib: "0x2E499f44d2977945d52B7BD7834B2C5195d9CE84",
       WitnetRequestBoard: "0x6cE42a35C61ccfb42907EEE57eDF14Bb69C7fEF4",
     },
   },
@@ -19,19 +19,19 @@ module.exports = {
       WitnetRequestBoard: "",
     },
     "boba.rinkeby": {
-      WitnetParserLib: "0xdF4Df677F645Fe603a883Ad3f2Db03EDFDd75F5C",
-      WitnetRequestBoard: "0xA2F4f5290F9cfD3a17Cfa82f2a2fD3E5c05d1442",
+      WitnetParserLib: "",
+      WitnetRequestBoard: "",
     },
   },
   celo: {
     "celo.alfajores": {
-      WitnetParserLib: "0x1C402c521C8dbF8aCF769d8445dC69c09E3505a5",
-      WitnetRequestBoard: "0x8e0F6f18DA49e548eBf845aFb6Ca98d43CBc8744",
+      WitnetParserLib: "0xfBFdDb3FeC361C6179d2A0deFAFD963735669EaA",
+      WitnetRequestBoard: "0x1AEC0089168Fd1c70B5df8b590c86FAdD62d0f2d",
     },
   },
   conflux: {
     "conflux.testnet": {
-      WitnetParserLib: "0x824ae04f47C6a8C08CbfE140fbd273Eb2E275795",
+      WitnetParserLib: "0x8d683e88E85f785180c68953933bA7752d1b1Dd3",
       WitnetRequestBoard: "0x8aB653B73a0e0552dDdce8c76F97c6AA826EFbD4",
     },
     "conflux.tethys": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "witnet-solidity-bridge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Witnet Solidity Bridge contracts for EVM-compatible networks",
   "main": "",
   "scripts": {

--- a/test/TestWitnetBuffer.sol
+++ b/test/TestWitnetBuffer.sol
@@ -13,6 +13,30 @@ contract TestWitnetBuffer {
 
   event Log(string _topic, uint256 _value);
 
+  function testRead31bytes() external {
+    bytes memory data = hex"58207eadcf3ba9a9a860b4421ee18caa6dca4738fef266aa7b3668a2ff97304cfcab";
+    Witnet.Buffer memory buf = Witnet.Buffer(data, 1);
+    bytes memory actual = buf.read(31);
+    
+    Assert.equal(31, actual.length, "Read 31 bytes from a Buffer");
+  }
+
+  function testRead32bytes() external {
+    bytes memory data = hex"58207eadcf3ba9a9a860b4421ee18caa6dca4738fef266aa7b3668a2ff97304cfcab";
+    Witnet.Buffer memory buf = Witnet.Buffer(data, 1);
+    bytes memory actual = buf.read(32);
+    
+    Assert.equal(32, actual.length, "Read 32 bytes from a Buffer");
+  }
+
+  function testRead33bytes() external {
+    bytes memory data = hex"58207eadcf3ba9a9a860b4421ee18caa6dca4738fef266aa7b3668a2ff97304cfcabff";
+    Witnet.Buffer memory buf = Witnet.Buffer(data, 1);
+    bytes memory actual = buf.read(33);
+    
+    Assert.equal(33, actual.length, "Read 33 bytes from a Buffer");
+  }
+
   function testReadUint8() external {
     uint8 expected = 31;
     bytes memory data = abi.encodePacked(expected);

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -14,8 +14,8 @@ if (!settings.networks[realm] || !settings.networks[realm][network]) {
   }
 }
 console.info(`
-> Targetting "${realm.toUpperCase()}" realm
-=====================${"=".repeat(realm.length)}`)
+Targetting "${realm.toUpperCase()}" realm
+===================${"=".repeat(realm.length)}`)
 module.exports = {
   build_directory: `./build/${realm}/`,
   contracts_directory: "./contracts/",


### PR DESCRIPTION
When copying 32-byte length bytes array.